### PR TITLE
style: refactor code to follow the Kotlin Style Guide

### DIFF
--- a/app/src/androidTest/java/com/calleb/numberguess/ExampleInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/calleb/numberguess/ExampleInstrumentedTest.kt
@@ -6,7 +6,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Test
 import org.junit.runner.RunWith
 
-import org.junit.Assert.*
+import org.junit.Assert.assertEquals
 
 /**
  * Instrumented test, which will execute on an Android device.

--- a/app/src/main/java/com/calleb/numberguess/MainActivity.kt
+++ b/app/src/main/java/com/calleb/numberguess/MainActivity.kt
@@ -3,7 +3,6 @@ package com.calleb.numberguess
 import android.content.Context
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
-import android.os.PersistableBundle
 import android.util.AttributeSet
 import android.util.Log
 import android.view.View
@@ -15,8 +14,8 @@ import kotlin.math.floor
 class MainActivity : AppCompatActivity() {
 
     private var started = false
-    private var number  = 0
-    private var tries   = 0
+    private var number = 0
+    private var tries = 0
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -25,41 +24,44 @@ class MainActivity : AppCompatActivity() {
         fetchSavedInstanceData(savedInstanceState)
 
         btnDoGuess.isEnabled = started
-        //btnDoGuess.visibility = View.GONE
+        // btnDoGuess.visibility = View.GONE
     }
 
-    //When the Button Start is clicked
-    fun start (v: View){
+    // When the Button Start is clicked
+    fun start(v: View) {
         log("Game started!")
         edtNum.setText("")
         started = true
         btnDoGuess.isEnabled = started
-        txtStatus.text = getString(R.string.guess_hint, 1,7)
-        number = 1 + floor(Math.random()*7).toInt() //Generates a random number
+        txtStatus.text = getString(R.string.guess_hint, 1, 7)
+        number = 1 + floor(Math.random() * 7).toInt() // Generates a random number
         tries = 0
-
     }
 
-    //When the Guess Button is clicked
-    fun guess(v: View){
-        if(edtNum.text.toString() == "") return
+    // When the Guess Button is clicked
+    fun guess(v: View) {
+        if (edtNum.text.toString() == "") return
 
         tries++
         log("Guessed number ${edtNum.text} in $tries tries")
 
         val g = edtNum.text.toString().toInt()
 
-        if (g < number){
-            txtStatus.setText(R.string.status_too_low)
-            edtNum.setText("")
-        }else if (g>number){
-            txtStatus.setText(R.string.status_too_high)
-            edtNum.setText("")
-        }else{
-            txtStatus.visibility = View.VISIBLE
-            txtStatus.text = getString(R.string.status_hit,tries)
-            started = false
-            btnDoGuess.isEnabled = started
+        when {
+            g < number -> {
+                txtStatus.setText(R.string.status_too_low)
+                edtNum.setText("")
+            }
+            g > number -> {
+                txtStatus.setText(R.string.status_too_high)
+                edtNum.setText("")
+            }
+            else -> {
+                txtStatus.visibility = View.VISIBLE
+                txtStatus.text = getString(R.string.status_hit, tries)
+                started = false
+                btnDoGuess.isEnabled = started
+            }
         }
     }
 
@@ -69,40 +71,43 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun putInstanceData(outState: Bundle?) {
-        if (outState != null) with(outState) {
-            putBoolean("started", started)
-            putInt("number", number)
-            putInt("tries", tries)
-            putString("statusMsg", txtStatus.text.toString())
-            putStringArrayList("logs",
-                ArrayList(console.text.split("\n")))
+        if (outState != null) {
+            with(outState) {
+                putBoolean("started", started)
+                putInt("number", number)
+                putInt("tries", tries)
+                putString("statusMsg", txtStatus.text.toString())
+                putStringArrayList("logs",
+                    ArrayList(console.text.split("\n")))
+            }
         }
     }
 
     private fun fetchSavedInstanceData(
-        savedInstanceState: Bundle?) {
-        if (savedInstanceState != null)
+        savedInstanceState: Bundle?
+    ) {
+        if (savedInstanceState != null) {
             with(savedInstanceState) {
                 started = getBoolean("started")
                 number = getInt("number")
                 tries = getInt("tries")
                 txtStatus.text = getString("statusMsg")
-                console.text = getStringArrayList("logs")!!.
-                    joinToString("\n")
+                console.text = getStringArrayList("logs")!!
+                    .joinToString("\n")
             }
+        }
     }
 
-    private fun log(msg:String) {
+    private fun log(msg: String) {
         Log.d("LOG", msg)
         console.log(msg)
     }
-
 }
 
 class Console(ctx: Context, aset: AttributeSet? = null)
     : ScrollView(ctx, aset) {
     val tv = TextView(ctx)
-    var text:String
+    var text: String
         get() = tv.text.toString()
         set(value) {
             tv.text = value
@@ -111,15 +116,11 @@ class Console(ctx: Context, aset: AttributeSet? = null)
         setBackgroundColor(0x40FFFF00)
         addView(tv)
     }
-    fun log(msg:String) {
+    fun log(msg: String) {
         val l = tv.text.let {
-            if(it == "") listOf() else it.split("\n")
+            if (it == "") listOf() else it.split("\n")
         }.takeLast(100) + msg
         tv.text = l.joinToString("\n")
-        post(object : Runnable {
-            override fun run() {
-                fullScroll(ScrollView.FOCUS_DOWN)
-            }
-        })
+        post { fullScroll(FOCUS_DOWN) }
     }
 }

--- a/app/src/test/java/com/calleb/numberguess/ExampleUnitTest.kt
+++ b/app/src/test/java/com/calleb/numberguess/ExampleUnitTest.kt
@@ -2,7 +2,7 @@ package com.calleb.numberguess
 
 import org.junit.Test
 
-import org.junit.Assert.*
+import org.junit.Assert.assertEquals
 
 /**
  * Example local unit test, which will execute on the development machine (host).


### PR DESCRIPTION
This PR should update our Kotlin code to follow the [Kotlin Style Guide](https://developer.android.com/kotlin/style-guide) recommended for Android.

With these changes, the code should now comply with the following rules:
- Separating reserved words (such as `if`) from parenthesis using a [horizontal whitespace](https://developer.android.com/kotlin/style-guide#horizontal);
- Wildcard imports (of any type) are not allowed in [import statements](https://developer.android.com/kotlin/style-guide#import_statements).

Additionally, I've also taken the liberty to:
- replace the `if` statement with a `when` structure;
- use a lambda function on the `post()` method call.
