### PR TITLE
refactor: create ViewModel for MainActivity

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.core:core-ktx:1.2.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
+    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0"
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test.ext:junit:1.1.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.1'

--- a/app/src/main/java/com/calleb/numberguess/MainActivity.kt
+++ b/app/src/main/java/com/calleb/numberguess/MainActivity.kt
@@ -8,99 +8,46 @@ import android.util.Log
 import android.view.View
 import android.widget.ScrollView
 import android.widget.TextView
+import androidx.lifecycle.Observer
+import androidx.lifecycle.ViewModelProvider
 import kotlinx.android.synthetic.main.activity_main.*
-import kotlin.math.floor
 
 class MainActivity : AppCompatActivity() {
 
-    private var started = false
-    private var number = 0
-    private var tries = 0
+    private lateinit var viewModel: MainActivityViewModel
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
 
-        fetchSavedInstanceData(savedInstanceState)
+        viewModel = ViewModelProvider(this).get(MainActivityViewModel::class.java)
 
-        btnDoGuess.isEnabled = started
-        // btnDoGuess.visibility = View.GONE
+        viewModel.gameStarted.observe(this, Observer { started ->
+            btnDoGuess.isEnabled = started
+            edtNum.isEnabled = started
+        })
+
+        viewModel.gameStatus.observe(this, Observer { status ->
+            txtStatus.text = status
+        })
+
+        viewModel.gameLog.observe(this, Observer { message ->
+            Log.d("LOG", message)
+            console.log(message)
+        })
     }
 
     // When the Button Start is clicked
     fun start(v: View) {
-        log("Game started!")
-        edtNum.setText("")
-        started = true
-        btnDoGuess.isEnabled = started
-        txtStatus.text = getString(R.string.guess_hint, 1, 7)
-        number = 1 + floor(Math.random() * 7).toInt() // Generates a random number
-        tries = 0
+        viewModel.startGame()
     }
 
     // When the Guess Button is clicked
     fun guess(v: View) {
         if (edtNum.text.toString() == "") return
-
-        tries++
-        log("Guessed number ${edtNum.text} in $tries tries")
-
         val g = edtNum.text.toString().toInt()
-
-        when {
-            g < number -> {
-                txtStatus.setText(R.string.status_too_low)
-                edtNum.setText("")
-            }
-            g > number -> {
-                txtStatus.setText(R.string.status_too_high)
-                edtNum.setText("")
-            }
-            else -> {
-                txtStatus.visibility = View.VISIBLE
-                txtStatus.text = getString(R.string.status_hit, tries)
-                started = false
-                btnDoGuess.isEnabled = started
-            }
-        }
-    }
-
-    override fun onSaveInstanceState(outState: Bundle) {
-        super.onSaveInstanceState(outState)
-        putInstanceData(outState)
-    }
-
-    private fun putInstanceData(outState: Bundle?) {
-        if (outState != null) {
-            with(outState) {
-                putBoolean("started", started)
-                putInt("number", number)
-                putInt("tries", tries)
-                putString("statusMsg", txtStatus.text.toString())
-                putStringArrayList("logs",
-                    ArrayList(console.text.split("\n")))
-            }
-        }
-    }
-
-    private fun fetchSavedInstanceData(
-        savedInstanceState: Bundle?
-    ) {
-        if (savedInstanceState != null) {
-            with(savedInstanceState) {
-                started = getBoolean("started")
-                number = getInt("number")
-                tries = getInt("tries")
-                txtStatus.text = getString("statusMsg")
-                console.text = getStringArrayList("logs")!!
-                    .joinToString("\n")
-            }
-        }
-    }
-
-    private fun log(msg: String) {
-        Log.d("LOG", msg)
-        console.log(msg)
+        viewModel.guess(g)
+        edtNum.setText("")
     }
 }
 

--- a/app/src/main/java/com/calleb/numberguess/MainActivityViewModel.kt
+++ b/app/src/main/java/com/calleb/numberguess/MainActivityViewModel.kt
@@ -1,0 +1,60 @@
+package com.calleb.numberguess
+
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import kotlin.math.floor
+
+class MainActivityViewModel : ViewModel() {
+
+    private var generatedNumber = 0
+    private var tryCount = 0
+
+    private val _gameStarted = MutableLiveData<Boolean>()
+    val gameStarted
+        get() = _gameStarted
+
+    private val _gameStatus = MutableLiveData<String>()
+    val gameStatus
+        get() = _gameStatus
+
+    private val _gameLog = MutableLiveData<String>()
+    val gameLog
+        get() = _gameLog
+
+    init {
+        _gameStarted.value = false
+        _gameStatus.value = ""
+        _gameLog.value = ""
+    }
+
+    private fun generateRandomNumber() = 1 + floor(Math.random() * 7).toInt()
+
+    fun guess(number: Int) {
+        tryCount++
+        log("Guessed number $number in $tryCount tries")
+        when {
+            number < generatedNumber -> {
+                _gameStatus.value = "Too low"
+            }
+            number > generatedNumber -> {
+                _gameStatus.value = "Too high"
+            }
+            number == generatedNumber-> {
+                _gameStatus.value = "You got it after $tryCount tries! Press START for a new game."
+                _gameStarted.value = false
+            }
+        }
+    }
+
+    private fun log(message: String) {
+        _gameLog.value = message
+    }
+
+    fun startGame(){
+        log("Game started!")
+        _gameStarted.value = true
+        generatedNumber = generateRandomNumber()
+        tryCount = 0
+        _gameStatus.value = "Guess a number between 1 and 7"
+    }
+}


### PR DESCRIPTION
This PR should refactor our code in order to follow Android's [Guide to App Architecture](https://developer.android.com/jetpack/docs/guide). I've moved most of the app logic to a [ViewModel](https://developer.android.com/jetpack/docs/guide), this way the Activity is only responsible for displaying data.

Some notes:
- String resources can't be accessed from a `ViewModel`, so I had to replace their usage with String literals.
- We're no longer saving the activity state. But we might be able to bring that back by using [Saved State for ViewModel](https://developer.android.com/topic/libraries/architecture/viewmodel-savedstate)(Currently in beta). I should be able to send a PR once I figure out how to use it.